### PR TITLE
Swap cheerio with htmlparser2

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/index.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: 'standard',
+	rules: {
+		'no-tabs': ['off'],
+		indent: ['error', 'tab']
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 Thumbs.db
 
+.vscode
+
 .nvm-version
 node_modules
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: node_js
 node_js:
-  - 'stable'
-  - 'lts/*'
-  - '6'
+  - '8'
+  - '10'
+  - lts/*
+  - node
+
+matrix:
+  include:
+    - node_js: '6'
+      env: NO_LINT=true
+
 script:
-  - 'npm run build'
-  - 'npm test'
+  - if [[ -z "${NO_LINT}" ]]; then npm run lint; fi
+  - npm run build
+  - npm test

--- a/example.js
+++ b/example.js
@@ -3,6 +3,6 @@
 const url = require('.')
 
 url('gilad_rom', 24148019753, url.sizes.original)
-.then(console.log)
-.catch(console.error)
+	.then(console.log)
+	.catch(console.error)
 // -> https://c2.staticflickr.com/2/1534/24148019753_bc3bb60f50_o.jpg

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
 		"node": ">=6"
 	},
 	"dependencies": {
-		"cheerio": "^1.0.0-rc.1",
 		"fetch-ponyfill": "^6.0.0",
+		"htmlparser2": "^4.0.0",
 		"pinkie-promise": "^2.0.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,16 @@
 		"pinkie-promise": "^2.0.1"
 	},
 	"devDependencies": {
-		"babel-cli": "^6.26.0",
-		"babel-preset-env": "^1.6.1",
+		"@babel/cli": "^7.5.5",
+		"@babel/core": "^7.5.5",
+		"@babel/preset-env": "^7.5.5",
 		"tap-min": "^1.2.0",
 		"tape-co": "^1"
 	},
 	"scripts": {
 		"build": "babel src/index.js --presets env --out-file index.js",
+		"build": "babel src/index.js --presets @babel/preset-env --out-file index.js",
+		"pretest": "npm run build",
 		"test": "node test.js | tap-min",
 		"prepublishOnly": "npm run build && npm test"
 	}

--- a/package.json
+++ b/package.json
@@ -30,11 +30,17 @@
 		"@babel/cli": "^7.5.5",
 		"@babel/core": "^7.5.5",
 		"@babel/preset-env": "^7.5.5",
+		"eslint": "^6.1.0",
+		"eslint-config-standard": "^13.0.1",
+		"eslint-plugin-import": "^2.18.2",
+		"eslint-plugin-node": "^9.1.0",
+		"eslint-plugin-promise": "^4.2.1",
+		"eslint-plugin-standard": "^4.0.0",
 		"tap-min": "^1.2.0",
 		"tape-co": "^1"
 	},
 	"scripts": {
-		"build": "babel src/index.js --presets env --out-file index.js",
+		"lint": "eslint .",
 		"build": "babel src/index.js --presets @babel/preset-env --out-file index.js",
 		"pretest": "npm run build",
 		"test": "node test.js | tap-min",

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ In opposition to [`flickr-photo-urls`](https://github.com/npm-flickr/flickr-phot
 [![dependency status](https://img.shields.io/david/derhuerst/flickr-photo-url.svg)](https://david-dm.org/derhuerst/flickr-photo-url)
 [![dev dependency status](https://img.shields.io/david/dev/derhuerst/flickr-photo-url.svg)](https://david-dm.org/derhuerst/flickr-photo-url#info=devDependencies)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com)
+[![install size](https://packagephobia.now.sh/badge?p=flickr-photo-url)](https://packagephobia.now.sh/result?p=flickr-photo-url)
 ![ISC-licensed](https://img.shields.io/github/license/derhuerst/flickr-photo-url.svg)
 [![chat on gitter](https://badges.gitter.im/derhuerst.svg)](https://gitter.im/derhuerst)
 [![support me on Patreon](https://img.shields.io/badge/support%20me-on%20patreon-fa7664.svg)](https://patreon.com/derhuerst)

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ In opposition to [`flickr-photo-urls`](https://github.com/npm-flickr/flickr-phot
 [![build status](https://img.shields.io/travis/derhuerst/flickr-photo-url.svg)](https://travis-ci.org/derhuerst/flickr-photo-url)
 [![dependency status](https://img.shields.io/david/derhuerst/flickr-photo-url.svg)](https://david-dm.org/derhuerst/flickr-photo-url)
 [![dev dependency status](https://img.shields.io/david/dev/derhuerst/flickr-photo-url.svg)](https://david-dm.org/derhuerst/flickr-photo-url#info=devDependencies)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com)
 ![ISC-licensed](https://img.shields.io/github/license/derhuerst/flickr-photo-url.svg)
 [![chat on gitter](https://badges.gitter.im/derhuerst.svg)](https://gitter.im/derhuerst)
 [![support me on Patreon](https://img.shields.io/badge/support%20me-on%20patreon-fa7664.svg)](https://patreon.com/derhuerst)
@@ -30,7 +31,7 @@ url(user, photoId, [size])
 const url = require('flickr-photo-url')
 
 url('gilad_rom', 24148019753, url.sizes.original)
-.catch(console.error).then(console.log)
+  .catch(console.error).then(console.log)
 // -> https://c2.staticflickr.com/2/1534/24148019753_bc3bb60f50_o.jpg
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const Promise = require('pinkie-promise')
-const {fetch} = require('fetch-ponyfill')({Promise})
-const {DomHandler, DomUtils, Parser} = require('htmlparser2')
+const { fetch } = require('fetch-ponyfill')({ Promise })
+const { DomHandler, DomUtils, Parser } = require('htmlparser2')
 
 const agent = 'derhuerst/flickr-photo-url'
 
@@ -14,41 +14,42 @@ sizes.small = 'n'
 sizes.square = 'q'
 
 const hasProp = (o, p) => Object.prototype.hasOwnProperty.call(o, p)
+const isString = arg => typeof arg === 'string'
+const isNumber = arg => typeof arg === 'number' || typeof arg === 'bigint'
 
 const url = (user, id, s) => {
-	if ('string' !== typeof user) return Promise.reject(new Error('invalid user'))
-	if ('number' !== typeof id) return Promise.reject(new Error('invalid photo id'))
-	if ('number' === typeof s) s = sizes[s] || sizes.original
-	else if ('string' === typeof s && sizes.indexOf(s) < 0 && !hasProp(sizes, s)) {
-		console.error(sizes.indexOf(s) < 0, !hasProp(sizes, s), s)
+	if (!isString(user)) return Promise.reject(new Error('invalid user'))
+	if (!isNumber(id)) return Promise.reject(new Error('invalid photo id'))
+	if (isNumber(s)) s = sizes[s] || sizes.original
+	else if (isString(s) && !sizes.includes(s) && !hasProp(sizes, s)) {
+		console.error(!sizes.includes(s), !hasProp(sizes, s), s)
 		return Promise.reject(new Error('invalid size'))
 	}
 
 	return fetch(`https://www.flickr.com/photos/${user}/${id}/sizes/${s}/`, {
 		redirect: 'follow',
-		headers: {'user-agent': agent}
+		headers: { 'user-agent': agent }
 	})
-	.then((res) => {
-		if (!res.ok) {
-			const err = new Error(res.statusText)
-			err.statusCode = res.status
-			throw err
-		}
-		return res.text()
-	})
-	.then((html) => {
-		const dom = parseHtml(html)
-		const container = DomUtils.getElementById('allsizes-photo', dom, true)
-		const img = DomUtils.findOne(el => el.tagName === 'img', [container], true)
-		const url = img.attribs.src
-		if (!url) throw new Error('failed to extract the URL from the Flickr page')
-		return url
-	})
+		.then((res) => {
+			if (!res.ok) {
+				const err = new Error(res.statusText)
+				err.statusCode = res.status
+				throw err
+			}
+			return res.text()
+		})
+		.then((html) => {
+			const dom = parseHtml(html)
+			const container = DomUtils.getElementById('allsizes-photo', dom, true)
+			const img = DomUtils.findOne(el => el.tagName === 'img', [container], true)
+			const url = img.attribs.src
+			if (!url) throw new Error('failed to extract the URL from the Flickr page')
+			return url
+		})
 }
 
-module.exports = Object.assign(url, {sizes})
+module.exports = Object.assign(url, { sizes })
 
-function parseHtml(html, options = {}) {
 function parseHtml (html, options = {}) {
 	const handler = new DomHandler(null, options)
 	new Parser(handler, options).end(html)

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const { DomHandler, DomUtils, Parser } = require('htmlparser2')
 
 const agent = 'derhuerst/flickr-photo-url'
 
+// Official size suffixes info: https://www.flickr.com/services/api/misc.urls.html
 const sizes = ['sq', 'q', 't', 's', 'n', 'm', 'z', 'c', 'l', 'h', 'k', 'o']
 sizes.original = 'o'
 sizes.large = 'k'

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const Promise = require('pinkie-promise')
 const {fetch} = require('fetch-ponyfill')({Promise})
-const cheerio = require('cheerio')
+const {DomHandler, DomUtils, Parser} = require('htmlparser2')
 
 const agent = 'derhuerst/flickr-photo-url'
 
@@ -37,11 +37,20 @@ const url = (user, id, s) => {
 		return res.text()
 	})
 	.then((html) => {
-		const $ = cheerio.load(html)
-		const url = $('#allsizes-photo img').attr('src')
+		const dom = parseHtml(html)
+		const container = DomUtils.getElementById('allsizes-photo', dom, true)
+		const img = DomUtils.findOne(el => el.tagName === 'img', [container], true)
+		const url = img.attribs.src
 		if (!url) throw new Error('failed to extract the URL from the Flickr page')
 		return url
 	})
 }
 
 module.exports = Object.assign(url, {sizes})
+
+function parseHtml(html, options = {}) {
+function parseHtml (html, options = {}) {
+	const handler = new DomHandler(null, options)
+	new Parser(handler, options).end(html)
+	return handler.dom
+}

--- a/test.js
+++ b/test.js
@@ -3,11 +3,9 @@
 const assert = require('assert')
 const test = require('tape-co').default
 const Promise = require('pinkie-promise')
-const fetch = require('fetch-ponyfill')({Promise: Promise}).fetch
+const { fetch } = require('fetch-ponyfill')(Promise)
 
-const url  = require('.')
-
-
+const url = require('.')
 
 const validUrl = (url) => {
 	return fetch(url, {
@@ -17,26 +15,22 @@ const validUrl = (url) => {
 			'user-agent': 'derhuerst/flickr-photo-url test'
 		}
 	})
-	.then((res) => {
-		assert(200 <= res.status, 'non-2xx status code')
-		assert(res.status < 300, 'non-2xx status code')
-		const type = res.headers.get('content-type').substr(0, 5)
-		assert.strictEqual(type, 'image', 'non-image mime type')
+		.then((res) => {
+			assert(res.status >= 200, 'non-2xx status code')
+			assert(res.status < 300, 'non-2xx status code')
+			const type = res.headers.get('content-type').substr(0, 5)
+			assert.strictEqual(type, 'image', 'non-image mime type')
 
-		return true // todo: abort res
-	})
+			return true // todo: abort res
+		})
 }
 
-
-
-test('works', function* (t) {
+test('works', function * (t) {
 	const original = yield url('gilad_rom', 24148019753)
 	t.ok(yield validUrl(original), 'valid url')
 })
 
-
-
-test('works with size `m`', function* (t) {
+test('works with size `m`', function * (t) {
 	const res = yield Promise.all([
 		url('gilad_rom', 24148019753),
 		url('gilad_rom', 24148019753, 'm')
@@ -48,9 +42,7 @@ test('works with size `m`', function* (t) {
 	t.ok(yield validUrl(medium), 'valid url')
 })
 
-
-
-test('works with size `small`', function* (t) {
+test('works with size `small`', function * (t) {
 	const res = yield Promise.all([
 		url('gilad_rom', 24148019753),
 		url('gilad_rom', 24148019753, url.sizes.small)


### PR DESCRIPTION
Hi Jannis 👋 

Thank you for making this useful package 👍 
I made some changes, hope you'll gonna like them.

Most important change is swapping [`cheerio`](https://npm.im/cheerio) with [`htmlparser2`](https://npm.im/htmlparser2). Reasoning behind this is because it significantly decreases install size of package. Compare following:
- [install size of cheerio (**2.76 MB**)](https://packagephobia.now.sh/result?p=cheerio)
- [install size of htmlparser2 (**401 kB**)](https://packagephobia.now.sh/result?p=htmlparser2)

Because `htmlparser2` is in fact used by `cheerio` this essentially means peeling off one layer of abstraction. It definitely results in _uglier_ code but that should be fine tradeoff keeping in mind gains in package size.

Other non-essential changes:
- configured ESLint (using [standard](https://standardjs.com) config because you obviously like it without semicolons 😉 )
- updated `.gitignore` with vscode folder
- updated Travis CI configuration (disabled linting on versions bellow `8` due to ESLint dropping support for those)
- upgraded babel cli & preset-env
- added code style & package size badges to readme